### PR TITLE
Add the ability to provide a "hint text"

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -6,7 +6,11 @@ void main() {
   var name = prompts.get('Enter your name');
   print('Hello, $name!');
 
-  var password = prompts.get('Enter a password', conceal: true);
+  var password = prompts.get(
+    'Enter a password',
+    conceal: true,
+    hintText: 'Make sure to keep this super secure!',
+  );
   print('TOP-SECRET: $password');
 
   // ... Or many lines.

--- a/lib/prompts.dart
+++ b/lib/prompts.dart
@@ -35,6 +35,10 @@ void clearLine() {
 ///
 /// [inputColor] may be used to give a color to the user's input as they type.
 ///
+/// [hintText] is an optional string to be shown as a hint/tooltip/alt/description
+/// of this field. It is shown below the prompt (on the next line) and is removed
+/// after the answer is accepted.
+///
 /// If [allowMultiline] is `true` (default: `false`), then lines ending in a
 /// backslash (`\`) will be interpreted as a signal that another line of
 /// input is to come. This is helpful for building REPL's.
@@ -46,7 +50,8 @@ String get(String message,
     bool color = true,
     bool allowMultiline = false,
     bool conceal = false,
-    AnsiCode inputColor = cyan}) {
+    AnsiCode inputColor = cyan,
+    String hintText}) {
   validate ??= (s) => s.trim().isNotEmpty;
 
   if (defaultsTo != null) {
@@ -81,6 +86,7 @@ String get(String message,
     // stdout.write(color ? inputColor?.escape ?? '' : '');
   }
 
+  writeHintText(hintText);
   while (true) {
     if (message.isNotEmpty) {
       writeIt();
@@ -141,6 +147,7 @@ String get(String message,
         // stdout.write(color ? resetAll.escape : '');
       }
 
+      clearHintText(hintText);
       return out;
     } else {
       code = red;
@@ -508,4 +515,16 @@ T chooseShorthand<T>(String message, Iterable<T> options,
   );
 
   return value;
+}
+
+void writeHintText(String hintText) {
+  if (hintText != null) {
+    stdout.write(darkGray.wrap('\n$hintText\u{1B}[1A\r'));
+  }
+}
+
+void clearHintText(String hintText) {
+  if (hintText != null) {
+    stdout.write('\r\u{1B}[K');
+  }
 }


### PR DESCRIPTION
So while using this great library I thought it would be cool to be able to add a more in-depth description of the field. I thought with some bash hackery I could add a line below the prompt with some sort of hint/description/alt of the field, and I thought it looked pretty cool. I did this on my project by wrapping your library calls but I thought you might want to consider it an interesting addition.

I am not sure though; it is a bit hacky using some escape sequences (not too much, I imagine you use that in other parts), and it might be too specific to my use case. But nonetheless, I leave it as a suggestion.

Here's a video of what it looks like:

[![asciicast](https://asciinema.org/a/chGcfDfFzsMVMquZiCFah4nGG.svg)](https://asciinema.org/a/chGcfDfFzsMVMquZiCFah4nGG)